### PR TITLE
Fixes alignment of notes in 2.5 example

### DIFF
--- a/index.md
+++ b/index.md
@@ -115,7 +115,7 @@ If we have a target that is a ".c" file, there is an *implicit command* that wil
 
 # Implicit command of: "cc -c blah.c -o blah.o"
 # Note: 1) Do not put a comment inside of the blah.o rule; the implicit rule will not run!
-# 		2) If there is no blah.c file, the implicit rule will not run and will not complain.
+#       2) If there is no blah.c file, the implicit rule will not run and will not complain.
 blah.o:
  
 clean:


### PR DESCRIPTION
Viewing the webpage on Firefox 31 on Debian Jessie the two notes on 2.5 are not aligned:

![Not aligned](http://i.imgur.com/nLlRqsd.png)

By using spaces instead of tabs the alignment should be consistent on different fonts, here's what the change looks like on my computer:

![Aligned](http://i.imgur.com/R6FU83u.png)
