### PR TITLE
Fix typo and add PHONY in section Static Pattern Rules and Filter

### DIFF
--- a/index.md
+++ b/index.md
@@ -326,14 +326,15 @@ obj_files = foo.elc bar.o lose.o
 src_files = foo.el bar.c lose.c
 
 all: $(obj_files)
+.PHONY: all
 
 $(filter %.o,$(obj_files)): %.o: %.c
-	echo "target: " $@ "prereq: " $<
+	echo "target: $@ prereq: $<"
 $(filter %.elc,$(obj_files)): %.elc: %.el
-	echo "target: " $@ "prereq: " $<
+	echo "target: $@ prereq: $<" 
 
 %.c %.el:
-	touch %@
+	touch $@
 
 clean:
 	rm -f $(src_files)


### PR DESCRIPTION
I suppose `%@` should be `$@` in section "Static Pattern Rules and Filter (Section 4.10)". And it looks like `.PHONY` was missing. 

To make the output consistent, I also update the echo statements a bit. 

Hope it helps. :)