### PR TITLE
Fix minor typo in `index.md`

### DIFF
--- a/src/index.md
+++ b/src/index.md
@@ -516,7 +516,7 @@ all:
 	# Same as running "sh_var='I am a shell variable'; echo $sh_var" in the shell
 	sh_var='I am a shell variable'; echo $$sh_var
 
-	# Same as running "echo I am a amke variable" in the shell
+	# Same as running "echo I am a make variable" in the shell
 	echo $(make_var)
 ```
 


### PR DESCRIPTION
Fix minor typo in `index.md`: `amke` -> `make`. Thanks for the tutorial btw :)