### PR TITLE
fix typo

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -716,7 +716,7 @@ modified. But it&#39;s important to realize that this isn&#39;t always the case.
 <span class="hljs-section">clean:</span>
 	rm -f file1 file2 some_file</code></pre>
 <p>Single or double quotes have no meaning to Make. They are simply characters that are assigned to the variable. Quotes <em>are</em> useful to shell/bash, though, and you need them in commands like <code>printf</code>. In this example, the two commands behave the same:</p>
-<pre><code class="hljs makefile">a := one two<span class="hljs-comment"># a is set to the string "one two"</span>
+<pre><code class="hljs makefile">a := one two <span class="hljs-comment"># a is set to the string "one two"</span>
 b := 'one two' <span class="hljs-comment"># Not recommended. b is set to the string "'one two'"</span>
 <span class="hljs-section">all:</span>
 	printf '$a'

--- a/docs/index.html
+++ b/docs/index.html
@@ -716,7 +716,7 @@ modified. But it&#39;s important to realize that this isn&#39;t always the case.
 <span class="hljs-section">clean:</span>
 	rm -f file1 file2 some_file</code></pre>
 <p>Single or double quotes have no meaning to Make. They are simply characters that are assigned to the variable. Quotes <em>are</em> useful to shell/bash, though, and you need them in commands like <code>printf</code>. In this example, the two commands behave the same:</p>
-<pre><code class="hljs makefile">a := one two <span class="hljs-comment"># a is set to the string "one two"</span>
+<pre><code class="hljs makefile">a := one two<span class="hljs-comment"># a is set to the string "one two"</span>
 b := 'one two' <span class="hljs-comment"># Not recommended. b is set to the string "'one two'"</span>
 <span class="hljs-section">all:</span>
 	printf '$a'

--- a/src/index.md
+++ b/src/index.md
@@ -189,7 +189,7 @@ clean:
 
 Single or double quotes have no meaning to Make. They are simply characters that are assigned to the variable. Quotes *are* useful to shell/bash, though, and you need them in commands like `printf`. In this example, the two commands behave the same:
 ```makefile
-a := one two # a is set to the string "one two"
+a := one two# a is set to the string "one two"
 b := 'one two' # Not recommended. b is set to the string "'one two'"
 all:
 	printf '$a'


### PR DESCRIPTION
When I run this in terminal

```
a := one two # a is set to the string "one two"
b := 'one two' # Not recommended. b is set to the string "'one two'"
all:
	printf '$a'
	printf $b
```

I got

```
$ github/test-makefile > make
printf 'one two '
one two printf 'one two' 
one two%    
```

notice 'one two ' has an extra space